### PR TITLE
This should find the room for most adaptors

### DIFF
--- a/scripts/standup.js
+++ b/scripts/standup.js
@@ -97,6 +97,15 @@ module.exports = function(robot) {
         robot.messageRoom(room, message);
     }
 
+    // Finds the room for most adaptors
+    function findRoom(msg) {
+        var room = msg.envelope.room;
+        if(room == undefined) {
+            room = msg.envelope.user.reply_to;
+        }
+        return room;
+    }
+
     // Stores a standup in the brain.
     function saveStandup(room, time) {
         var standups = getStandups();
@@ -146,13 +155,13 @@ module.exports = function(robot) {
     }
 
     robot.respond(/delete all standups/i, function(msg) {
-        var standupsCleared = clearAllStandupsForRoom(msg.envelope.user.reply_to);
+        var standupsCleared = clearAllStandupsForRoom(findRoom(msg));
         msg.send('Deleted ' + standupsCleared + ' standup' + (standupsCleared === 1 ? '' : 's') + '. No more standups for you.');
     });
 
     robot.respond(/delete ([0-5]?[0-9]:[0-5]?[0-9]) standup/i, function(msg) {
         var time = msg.match[1]
-        var standupsCleared = clearSpecificStandupForRoom(msg.envelope.user.reply_to, time);
+        var standupsCleared = clearSpecificStandupForRoom(findRoom(msg), time);
         if (standupsCleared === 0) {
             msg.send("Nice try. You don't even have a standup at " + time);
         }
@@ -164,17 +173,14 @@ module.exports = function(robot) {
     robot.respond(/create standup ([0-5]?[0-9]:[0-5]?[0-9])$/i, function(msg) {
         var time = msg.match[1];
 
-        // NOTE: This works for Hipchat. You may need to change this line to 
-        // match your adapter. 'room' must be saved in a format that will
-        // work with the robot.messageRoom function.
-        var room = msg.envelope.user.reply_to;
+        var room = findRoom(msg);
 
         saveStandup(room, time);
         msg.send("Ok, from now on I'll remind this room to do a standup every weekday at " + time);
     });
 
     robot.respond(/list standups$/i, function(msg) {
-        var standups = getStandupsForRoom(msg.envelope.user.reply_to);
+        var standups = getStandupsForRoom(findRoom(msg));
 
         if (standups.length === 0) {
             msg.send("Well this is awkward. You haven't got any standups set :-/");


### PR DESCRIPTION
I've tried using this plugin on a couple of platforms and as noted in the code it doesn't always correctly identify the channel to notify. Digging into it a little it seems most adaptors put the current channel into msg.envelope.room, with the DM user being stored in msg.envelope.user.reply_to . This PR changes the preference to the current room field and then if it's a DM falls back to msg.envelope.user.reply_to

Verified in irc. Checked other common adaptors and they seem to conform to this pattern.
